### PR TITLE
Add ability to specific multiple context files on CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Use the `--context <FILE PATH>` command line option (or `-c` as a short version)
 
 `python chatgpt.py --context notes.txt`
 
-Both absolute and relative paths are accepted.
+Both absolute and relative paths are accepted. Note that this option can be specified multiple times to give multiple files for context. Example:
+
+`python chatgpt.py --context notes-from-thursday.txt --context notes-from-friday.txt`
 
 Typical use cases for this feature are:
 

--- a/chatgpt.py
+++ b/chatgpt.py
@@ -175,7 +175,8 @@ def start_prompt(session: PromptSession, config: dict) -> None:
 
 @click.command()
 @click.option(
-    "-c", "--context", "context", type=click.File("r"), help="Path to a context file"
+    "-c", "--context", "context", type=click.File("r"), help="Path to a context file",
+    multiple=True
 )
 @click.option("-k", "--key", "api_key", help="Set the API Key")
 def main(context, api_key) -> None:
@@ -210,8 +211,9 @@ def main(context, api_key) -> None:
 
     # Context from the command line option
     if context:
-        console.print(f"Context file: [green bold]{context.name}")
-        messages.append({"role": "system", "content": context.read().strip()})
+        for c in context:
+            console.print(f"Context file: [green bold]{c.name}")
+            messages.append({"role": "system", "content": c.read().strip()})
 
     console.rule()
 


### PR DESCRIPTION
Adding multiple context files can be useful when comparing two files or just increasing the general context that GPT has on the question that you're asking. This allows specifying the `-c/--context` flag multiple times to provide additional context files.